### PR TITLE
set global header flag for all media types

### DIFF
--- a/live_segmenter.c
+++ b/live_segmenter.c
@@ -65,6 +65,11 @@ static AVStream *add_output_stream(AVFormatContext *output_format_context, AVStr
     output_codec_context->time_base = input_stream->time_base;
   }
 
+  if (output_format_context->oformat->flags & AVFMT_GLOBALHEADER) 
+  {
+      output_codec_context->flags |= CODEC_FLAG_GLOBAL_HEADER;
+  }
+
   switch (input_codec_context->codec_type) 
   {
     case AVMEDIA_TYPE_AUDIO:
@@ -86,11 +91,6 @@ static AVStream *add_output_stream(AVFormatContext *output_format_context, AVStr
       output_codec_context->width = input_codec_context->width;
       output_codec_context->height = input_codec_context->height;
       output_codec_context->has_b_frames = input_codec_context->has_b_frames;
-
-      if (output_format_context->oformat->flags & AVFMT_GLOBALHEADER) 
-      {
-          output_codec_context->flags |= CODEC_FLAG_GLOBAL_HEADER;
-      }
       break;
     default:
       break;


### PR DESCRIPTION
When the output format requires global headers, 
CODEC_FLAG_GLOBAL_HEADER should be set for all codec media types.

This appears to be a very old bug, inherited from the 2009 version of output_example.c

This fix uses the same approach currently in new_output_stream() 
in both avconv_opt.c and ffmpeg_opt.c (just search for CODEC_FLAG_GLOBAL_HEADER)

It is also present in a slightly different form in add_audio_stream() of libavformat/output-example.c
see: libav change 073189917e4dfa0640e8180110b07e130471f37f
Make output-example.c handle AAC audio.
Patch by Martin Storsjö martin martin st
Originally committed as revision 21367 to svn://svn.ffmpeg.org/ffmpeg/trunk
